### PR TITLE
pin install requirements to prevent forge startup crash

### DIFF
--- a/flux-layerdiffuse/install.py
+++ b/flux-layerdiffuse/install.py
@@ -5,11 +5,11 @@ import os
 print("[FLUX LayerDiffuse] Checking and installing requirements (from install.py)...")
 
 requirements = {
-    "diffusers": "diffusers>=0.27.0", 
-    "transformers": "transformers>=4.38.0",
-    "safetensors": "safetensors>=0.4.0",
-    "accelerate": "accelerate>=0.25.0",
-    "opencv-python-headless": "opencv-python-headless" # For cv2 used in TransparentVAE
+    "diffusers": "diffusers==0.28.2", 
+    "transformers": "transformers==4.41.2",
+    "safetensors": "safetensors==0.4.3",
+    "accelerate": "accelerate==0.30.1",
+    "opencv-python-headless": "opencv-python-headless==4.9.0.80"
 }
 
 for package_name, requirement_str in requirements.items():


### PR DESCRIPTION
Ran into a startup crash after installing the extension on the latest Forge release. 

Since the script uses `>=` with the `--upgrade` flag, pip pulls down the latest updates for the required packages. This ends up pulling in NumPy 2.2.6 as a dependency and force-upgrades the environment.

Forge's core dependencies (like scipy and pandas) are built for NumPy 1.x and break immediately on launch when NumPy 2.x gets installed, throwing these errors:

```text
...\webui_forge_cu121_torch231\webui\backend\stream.py:21: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at ..\torch\csrc\utils\tensor_numpy.cpp:84.)
  torch.zeros((1, 1)).to(device, torch.float32)
  
...
  
...\webui_forge_cu121_torch231\system\python\lib\site-packages\transformers\loss\loss_for_object_detection.py:28: UserWarning: A NumPy version >=1.22.4 and <1.29.0 is required for this version of SciPy (detected version 2.2.6)
  from scipy.optimize import linear_sum_assignment
  
...

File "...\site-packages\onnxruntime\capi\_pybind_state.py", line 32, in <module>
    from .onnxruntime_pybind11_state import *  # noqa
AttributeError: _ARRAY_API not found

...

File "interval.pyx", line 1, in init pandas._libs.interval
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

To fix this, I pinned the requirements to the versions released right before the NumPy 2.0. This keeps the environment on NumPy 1.x and stops the crash.

Tested and working fine on:
Forge Version: f2.0.1v1.10.1-previous-669-gdfdcbab6 (latest GitHub release, fully updated)